### PR TITLE
[142] `organic-stem-skeleton` generic improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
 public/
+upgrades/client/apps/organic-oval-fu/core/client/vendor/

--- a/core/package.json
+++ b/core/package.json
@@ -24,8 +24,8 @@
     "organic-angel": "^0.3.2",
     "organic-bunyan-output": "0.0.4",
     "organic-console": "0.0.2",
-    "organic-dna-loader": "1.0.0",
-    "organic-express-response": "0.0.2",
+    "organic-dna-loader": "1.2.0",
+    "organic-express-response": "0.0.3",
     "organic-express-routes": "^0.1.1",
     "organic-express-server": "0.0.2",
     "organic-express-static": "0.0.2",
@@ -34,7 +34,7 @@
     "organic-plasma-feedback": "^1.0.0"
   },
   "devDependencies": {
-    "angelscripts-help": "0.1.0",
+    "angelscripts-help": "0.2.0",
     "angelscripts-stack-use": "^0.1.4",
     "bunyan-format": "^0.2.1",
     "eslint": "^1.10.3",

--- a/test/server/mocha-chai.test.js
+++ b/test/server/mocha-chai.test.js
@@ -1,21 +1,48 @@
-describe('mocha with chai', function () {
-  var stemCell = new StemSkeleton(require(process.cwd() + '/mock-stemskeleton.json'))
-  before(function (next) {
-    stemCell.mockTestFolder(next)
+describe('mocha with chai ', function () {
+  describe('without client pages', function () {
+    var stemCell = new StemSkeleton(require(process.cwd() + '/mock-stemskeleton.json'))
+    before(function (next) {
+      stemCell.mockTestFolder(next)
+    })
+    before(function (next) {
+      stemCell.stackUpgrade('core', next)
+    })
+    before(function (next) {
+      stemCell.stackUpgrade('mocha-chai', next)
+    })
+    after(function (next) {
+      stemCell.removeMockedFolder(next)
+    })
+    it('$angel test', function (next) {
+      stemCell.exec('angel test', function (err, stdout) {
+        if (err) return next(err)
+        next()
+      })
+    })
   })
-  before(function (next) {
-    stemCell.stackUpgrade('core', next)
-  })
-  before(function (next) {
-    stemCell.stackUpgrade('mocha-chai', next)
-  })
-  after(function (next) {
-    stemCell.removeMockedFolder(next)
-  })
-  it('$angel test', function (next) {
-    stemCell.exec('angel test', function (err, stdout) {
-      if (err) return next(err)
-      next()
+
+  describe('with client pages', function () {
+    var stemCell = new StemSkeleton(require(process.cwd() + '/mock-stemskeleton.json'))
+    before(function (next) {
+      stemCell.mockTestFolder(next)
+    })
+    before(function (next) {
+      stemCell.stackUpgrade('core', next)
+    })
+    before(function (next) {
+      stemCell.stackUpgrade('mocha-chai', next)
+    })
+    before(function (next) {
+      stemCell.stackUpgrade('ejs-pages', next)
+    })
+    after(function (next) {
+      stemCell.removeMockedFolder(next)
+    })
+    it('$angel test', function (next) {
+      stemCell.exec('angel test', function (err, stdout) {
+        if (err) return next(err)
+        next()
+      })
     })
   })
 })

--- a/upgrades/client/apps/organic-oval-fu/core/.eslintignore
+++ b/upgrades/client/apps/organic-oval-fu/core/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+build/
+public/
+client/vendor/

--- a/upgrades/client/apps/organic-oval-fu/core/client/common/cell.js
+++ b/upgrades/client/apps/organic-oval-fu/core/client/common/cell.js
@@ -1,3 +1,4 @@
+/* global oval */
 if (typeof Promise === 'undefined') {
   require('es6-promise').polyfill()
 }

--- a/upgrades/client/apps/organic-oval-fu/core/client/common/plasma/api.js
+++ b/upgrades/client/apps/organic-oval-fu/core/client/common/plasma/api.js
@@ -1,3 +1,4 @@
+/* global fetch */
 var dna = require('webpack-dna-loader!')
 
 var restful = require('restful.js')

--- a/upgrades/client/apps/organic-oval-fu/core/client/common/plasma/current-user.js
+++ b/upgrades/client/apps/organic-oval-fu/core/client/common/plasma/current-user.js
@@ -1,5 +1,5 @@
 var _ = require('lodash')
-var FormData = window.FormData
+var FormData = window.FormData // eslint-disable-line no-unused-vars
 var User = require('../models/user')
 
 module.exports = function CurrentUser (plasma) {

--- a/upgrades/server/mocha-chai/package.json
+++ b/upgrades/server/mocha-chai/package.json
@@ -9,8 +9,9 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "faker": "^3.1.0",
-    "mocha": "^2.4.5",
+    "mocha": "^3.0.2",
     "rimraf": "^2.5.2",
-    "request": "^2.69.0"
+    "request": "^2.69.0",
+    "lodash": "^4.17.4"
   }
 }

--- a/upgrades/server/mocha-chai/scripts/test.js
+++ b/upgrades/server/mocha-chai/scripts/test.js
@@ -9,16 +9,25 @@ module.exports = function (angel) {
       'node ./node_modules/.bin/mocha ./test'
     ].join(' && '), handleExit)
   })
+  .example('angel test')
+  .description('1. checks the codestyle via eslint\n' +
+               '2. runs all Mocha tests in "test/"\n')
+
   angel.on('test style', function (angel, next) {
     require('angelabilities-exec')(angel)
     angel.sh([
       'node ./node_modules/.bin/eslint ./'
     ].join(' && '), handleExit)
   })
+  .example('angel test style')
+  .description('checks the codestyle via eslint')
+
   angel.on('test :path', function (angel, next) {
     require('angelabilities-exec')(angel)
     angel.sh([
       'node ./node_modules/.bin/mocha ' + angel.cmdData.path
     ].join(' && '), handleExit)
   })
+  .example('angel test test/server')
+  .description('runs all Mocha tests in ":path"')
 }

--- a/upgrades/server/mocha-chai/test/helpers/index.js
+++ b/upgrades/server/mocha-chai/test/helpers/index.js
@@ -5,6 +5,7 @@ process.env.CELL_MODE = process.env.CELL_MODE || '_test'
 
 var path = require('path')
 var chai = require('chai')
+var _ = require('lodash')
 
 global.expect = chai.expect
 
@@ -35,7 +36,8 @@ test.startServer = function (next) {
   test.initTestEnv(function (err) {
     if (err) return next(err)
     var cell = variables.cell = require('../../server/start')()
-    cell.plasma.on(['ApiRoutesReady'], function (err) {
+    var readyChemcals = _.get(test.variables, 'dna.server.processes.index.membrane.organic-express-server.expressSetupDoneOnce', ['ApiRoutesReady'])
+    cell.plasma.on(readyChemcals, function (err) {
       if (err instanceof Error) return next(err)
       next && next()
     })

--- a/upgrades/server/mongoose/package.json
+++ b/upgrades/server/mongoose/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "mongoose": "3.8.15",
-    "organic-mongoose": "0.1.0"
+    "mongoose": "^4.8.0",
+    "organic-mongoose": "0.1.1"
   }
 }


### PR DESCRIPTION
## Trello card https://trello.com/c/6lfPAM39/142-organic-stem-skeleton-improvements
## General

This PR brings a round of generic refinements and refreshments to the stem skeleton, as well as several minor bugfixes.

## Notable changes

- Dependency version bumps - `organic-dna-loader`, `organic-express-response`, `angelscripts-help`, `mocha`, `organic-mongoose`, `mongoose` (major version change but no breaking changes spotted - https://github.com/Automattic/mongoose/blob/master/History.md)
- :warning:  Fixed issue with the default `test.startServer` test suite helper (from the `mocha-chai` stack upgrade) failing when one of the `ejs-pages`/`jade-pages` stack upgrades is installed. The test helper will now get the set of required chemicals needed to consider the server as started from the dna `dna.server.processes.index.membrane.organic-express-server.expressSetupDoneOnce` (vs hardcoding them).
- Fixed several eslint issues in the `organic-oval-fu` stack upgrade:
  * Ignored the `vendor` folder in the main `.eslintignore`
  * :warning: Added an `.eslintignore` upgrade which will overwrite the root one. It includes the `client/vendor` folder.
  * :warning: Fixed several eslint errors with inline comment configs. This way global eslint rules specific to the stack upgrade can be avoided.

## Accompanying PRs
- https://github.com/outbounder/organic-stem-tester/pull/2
- https://github.com/outbounder/organic-stem-devtools/pull/4
