### PR TITLE
Electron stack upgrade

### DIFF
--- a/core/dna/_test/server/processes/index.json
+++ b/core/dna/_test/server/processes/index.json
@@ -1,10 +1,10 @@
 {
+  "port": 13371,
   "membrane": {
     "bunyan-output": {
       "bunyanInit": "server/initializers/bunyan-development"
     },
     "organic-express-server": {
-      "port": 13371,
       "uploadsDir": "test/uploads"
     }
   }

--- a/core/dna/server/processes/index.json
+++ b/core/dna/server/processes/index.json
@@ -1,4 +1,5 @@
 {
+  "port": 1337,
   "plasma": {
     "organic-api-routes": {
       "source": "organic-express-routes",
@@ -35,7 +36,7 @@
     "organic-express-server": {
       "source": "organic-express-server",
       "forceConnectionsDestroyOnClose": true,
-      "port": 1337,
+      "port": "@server.processes.index.port",
       "initScript": "server/initializers/express-app.js",
       "emitReady": "ExpressServer",
       "uploadsDir": "uploads",

--- a/test/server/electron.test.js
+++ b/test/server/electron.test.js
@@ -1,0 +1,30 @@
+var spawn = require('child_process').spawn
+
+describe('electron', function () {
+  var stemCell = new StemSkeleton(require(process.cwd() + '/mock-stemskeleton.json'))
+  before(function (next) {
+    stemCell.mockTestFolder(next)
+  })
+  before(function (next) {
+    stemCell.stackUpgrade('core', next)
+  })
+  before(function (next) {
+    this.timeout(3 * 60000)
+    stemCell.stackUpgrade('electron', next)
+  })
+  after(function (next) {
+    stemCell.removeMockedFolder(next)
+  })
+  it('electron app runs in development mode', function (next) {
+    var child = spawn('node', ['./bin/electron-app.js'], {
+      cwd: stemCell.targetDir,
+      env: Object.assign({
+        CELL_MODE: '_development'
+      }, process.env)
+    })
+    setTimeout(function () {
+      child.kill('SIGTERM')
+      next()
+    }, 2 * 1000)
+  })
+})

--- a/upgrades/server/electron/core/bin/electron-app.js
+++ b/upgrades/server/electron/core/bin/electron-app.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+var path = require('path')
+var spawn = require('child_process').spawn
+var electron = require('electron')
+var app_path = path.join(__dirname, '/../')
+
+var child = spawn(electron, [app_path])
+
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
+child.on('exit', function (code) {
+  process.exit(code)
+})
+process.on('SIGTERM', function () {
+  child.kill()
+  process.exit(0)
+})

--- a/upgrades/server/electron/core/dna/server/processes/index.json
+++ b/upgrades/server/electron/core/dna/server/processes/index.json
@@ -1,0 +1,9 @@
+{
+  "plasma": {
+    "mainWindow": {
+      "source": "./server/plasma/mainWindow",
+      "reactOn": "ApiRoutesReady",
+      "url": "http://localhost:@{server.processes.index.port}"
+    }
+  }
+}

--- a/upgrades/server/electron/core/package.json
+++ b/upgrades/server/electron/core/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "electron": "1.6.6"
+  }
+}

--- a/upgrades/server/electron/core/scripts/develop-electron.js
+++ b/upgrades/server/electron/core/scripts/develop-electron.js
@@ -1,0 +1,13 @@
+module.exports = function (angel) {
+  angel.on('develop electron', function (angel) {
+    process.env.CELL_MODE = process.env.CELL_MODE || '_development'
+    var parallel = require('organic-stem-devtools/lib/parallel-exec')
+    parallel([
+      'node ./node_modules/.bin/angel watch',
+      'node ./bin/electron-app.js'
+    ])
+  })
+  .example('angel develop electron')
+  .description('1. runs "angel watch" which builds and watches the client impl. for changes\n' +
+               '2. starts the electron app')
+}

--- a/upgrades/server/electron/core/server/plasma/mainWindow/index.js
+++ b/upgrades/server/electron/core/server/plasma/mainWindow/index.js
@@ -1,0 +1,75 @@
+var Tray = require('electron').Tray
+var BrowserWindow = require('electron').BrowserWindow
+var app = require('electron').app
+var globalShortcut = require('electron').globalShortcut
+
+module.exports = function (plasma, dna) {
+  plasma.on('kill', function () {
+    if (dna.globalShortcut) {
+      globalShortcut.unregister(dna.globalShortcut)
+    }
+
+    // On OS X it is common for applications and their menu bar
+    // to stay active until the user quits explicitly with Cmd + Q
+    if (process.platform !== 'darwin') {
+      app.quit()
+    }
+  })
+
+  plasma.on(dna.reactOn, function () {
+    // Keep a global reference of the window object, if you don't, the window will
+    // be closed automatically when the JavaScript object is garbage collected.
+    var mainWindow = global['mainWindow'] = null
+
+    // Quit when all windows are closed.
+    app.on('window-all-closed', function () {
+      plasma.emit('kill')
+    })
+
+    // Create the browser window.
+    mainWindow = new BrowserWindow({
+      width: 800,
+      height: 600,
+      'web-preferences': {
+        preload: __dirname + '/preload.js'
+      },
+      frame: true,
+      icon: __dirname + dna.mainWindowIconPath
+    })
+
+    // and load the index.html of the app.
+    mainWindow.loadURL(dna.url)
+
+    // Open the DevTools.
+    if (dna.devTools) {
+      mainWindow.openDevTools()
+    }
+
+    // setup TrayIcon
+    if (dna.trayIcon) {
+      var appIcon = global['appIcon'] = new Tray(__dirname + dna.trayIconPath)
+      appIcon.setToolTip(dna.trayIconTooltip)
+      appIcon.on('clicked', function () {
+        if (mainWindow.isVisible()) {
+          mainWindow.hide()
+        } else {
+          mainWindow.show()
+        }
+      })
+    }
+
+    if (dna.globalShortcut) {
+      var ret = globalShortcut.register(dna.globalShortcut, function () {
+        if (mainWindow.isVisible()) {
+          mainWindow.hide()
+        } else {
+          mainWindow.show()
+        }
+      })
+
+      if (!ret) {
+        console.info('registration failed for ' + dna.globalShortcut)
+      }
+    }
+  })
+}

--- a/upgrades/server/electron/core/server/plasma/mainWindow/preload.js
+++ b/upgrades/server/electron/core/server/plasma/mainWindow/preload.js
@@ -1,0 +1,12 @@
+(function () {
+  window.frame = require('remote').getCurrentWindow()
+  window.frame.resizeTo = function (w, h) {
+    window.frame.setSize(w, h)
+  }
+  window.frame.bringToFront = function () {
+    window.frame.show()
+  }
+  window.frame.setAppTrayIcon = function (path) {
+    require('remote').getGlobal('appIcon').setImage(path)
+  }
+})()

--- a/upgrades/server/electron/upgrade.json
+++ b/upgrades/server/electron/upgrade.json
@@ -1,0 +1,8 @@
+{
+  "name": "electron",
+  "version": "1.0.0",
+  "main": "core",
+  "dependencies": {
+    "core": "1.0.0"
+  }
+}


### PR DESCRIPTION
This PR brings simple electron strack upgrade aligned to organic-stem-skeleton's `client` and `server` duo:

# electron stack upgrade 

* `server` is the main entry point which uses `server/plasma/mainWindow` organelle to bring an electron main window loading the client at `http://localhost:@{server.processes.index.port}`
* `client` is compiled and served to the electron main window via static http `server`

# core changes

* moved `server.processes.index.organic-express-server.port` value to `server.processes.index.port` so that organelles needing that info can reference it shortly